### PR TITLE
Require non-empty arrays in rulesets

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -26,7 +26,6 @@
   "devDependencies": {
     "purescript-console": "^4.1.0",
     "purescript-effect": "^2.0.0",
-    "purescript-partial": "^2.0.0",
     "purescript-psci-support": "^4.0.0"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -26,6 +26,7 @@
   "devDependencies": {
     "purescript-console": "^4.1.0",
     "purescript-effect": "^2.0.0",
+    "purescript-partial": "^2.0.0",
     "purescript-psci-support": "^4.0.0"
   }
 }

--- a/src/Style/Render.purs
+++ b/src/Style/Render.purs
@@ -3,8 +3,9 @@ module Style.Render where
 import Prelude
 
 import Data.Array (intercalate)
+import Data.Array.NonEmpty (NonEmptyArray)
 import Style.Declaration (Declaration)
 import Style.Declaration as Declaration
 
-inline :: Array Declaration -> String
+inline :: NonEmptyArray Declaration -> String
 inline = intercalate " " <<< map Declaration.render

--- a/src/Style/Ruleset.purs
+++ b/src/Style/Ruleset.purs
@@ -3,19 +3,18 @@ module Style.Ruleset where
 import Prelude
 
 import Data.Array as Array
+import Data.Array.NonEmpty (NonEmptyArray)
 import Style.Declaration (Declaration)
 import Style.Declaration as Declaration
 import Style.Selector (Selector)
 import Style.Selector as Selector
 
-data Ruleset = Ruleset (Array Selector) (Array Declaration)
+data Ruleset = Ruleset (NonEmptyArray Selector) (NonEmptyArray Declaration)
 
 derive instance eqRuleset :: Eq Ruleset
 derive instance ordRuleset :: Ord Ruleset
 
 render :: Ruleset -> String
-render (Ruleset [] _) = ""
-render (Ruleset _ []) = ""
 render (Ruleset ss ds) = selectors <> "{" <> declarations <> "}"
 
   where

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -3,8 +3,11 @@ module Test.Main where
 import Prelude hiding (zero)
 
 import Color (black, rgb)
+import Data.Array.NonEmpty (NonEmptyArray, fromArray)
+import Data.Maybe (fromJust)
 import Effect (Effect)
 import Effect.Console (log)
+import Partial.Unsafe (unsafePartial)
 import Style.Declaration (Declaration, backgroundColor, borderRadius, color, fontSize, height, margin, padding, textAlign, width)
 import Style.Declaration.Value (auto, center, em, pct, px, zero)
 import Style.Render (inline)
@@ -12,15 +15,18 @@ import Style.Ruleset (Ruleset(..))
 import Style.Ruleset as Ruleset
 import Style.Selector (Selector(..))
 
-selectors :: Array Selector
-selectors =
+unsafeFromArray :: Array ~> NonEmptyArray
+unsafeFromArray = unsafePartial fromJust <<< fromArray
+
+selectors :: NonEmptyArray Selector
+selectors = unsafeFromArray
   [ TypeSelector "body"
   , ClassSelector "foo"
   , IDSelector "bar"
   ]
 
-declarations :: Array Declaration
-declarations =
+declarations :: NonEmptyArray Declaration
+declarations = unsafeFromArray
   [ backgroundColor $ rgb 127 127 127
   , borderRadius $ 8.0 # px
   , color black

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -4,10 +4,9 @@ import Prelude hiding (zero)
 
 import Color (black, rgb)
 import Data.Array.NonEmpty (NonEmptyArray, fromArray)
-import Data.Maybe (fromJust)
+import Data.Maybe (Maybe, maybe)
 import Effect (Effect)
 import Effect.Console (log)
-import Partial.Unsafe (unsafePartial)
 import Style.Declaration (Declaration, backgroundColor, borderRadius, color, fontSize, height, margin, padding, textAlign, width)
 import Style.Declaration.Value (auto, center, em, pct, px, zero)
 import Style.Render (inline)
@@ -15,18 +14,15 @@ import Style.Ruleset (Ruleset(..))
 import Style.Ruleset as Ruleset
 import Style.Selector (Selector(..))
 
-unsafeFromArray :: Array ~> NonEmptyArray
-unsafeFromArray = unsafePartial fromJust <<< fromArray
-
-selectors :: NonEmptyArray Selector
-selectors = unsafeFromArray
+selectors :: Maybe (NonEmptyArray Selector)
+selectors = fromArray
   [ TypeSelector "body"
   , ClassSelector "foo"
   , IDSelector "bar"
   ]
 
-declarations :: NonEmptyArray Declaration
-declarations = unsafeFromArray
+declarations :: Maybe (NonEmptyArray Declaration)
+declarations = fromArray
   [ backgroundColor $ rgb 127 127 127
   , borderRadius $ 8.0 # px
   , color black
@@ -38,13 +34,13 @@ declarations = unsafeFromArray
   , width auto
   ]
 
-ruleset :: Ruleset
-ruleset = Ruleset selectors declarations
+ruleset :: Maybe Ruleset
+ruleset = Ruleset <$> selectors <*> declarations
 
 main :: Effect Unit
 main = do
   log ""
-  log $ inline declarations
+  log $ maybe "" inline declarations
   log ""
-  log $ Ruleset.render ruleset
+  log $ maybe "" Ruleset.render ruleset
   log ""


### PR DESCRIPTION
This is in response to https://github.com/paulyoung/purescript-style/pull/16#issuecomment-397650329.

Now that I've done this I'm a little hesitant to make this change since it either complicates the public API or forces consumers to deal with `Maybe` by using `fromArray`. 

I've skirted around this in the "test" by doing something unsafe. Perhaps dealing with `Maybe` isn't so bad.

@joneshf do you have any suggestions here?