### PR TITLE
Add shorthand functions

### DIFF
--- a/src/Style/Declaration.purs
+++ b/src/Style/Declaration.purs
@@ -48,8 +48,30 @@ type BorderRadiusValue =
     + ()
     )
 
-borderRadius :: BorderRadiusValue -> Declaration
-borderRadius = Declaration BorderRadius <<< expand
+borderRadius
+  :: BorderRadiusValue
+  -> BorderRadiusValue
+  -> BorderRadiusValue
+  -> BorderRadiusValue
+  -> Array Declaration
+borderRadius tl tr br bl =
+  [ borderTopLeftRadius tl
+  , borderTopRightRadius tr
+  , borderBottomRightRadius br
+  , borderBottomLeftRadius bl
+  ]
+
+borderBottomLeftRadius :: BorderRadiusValue -> Declaration
+borderBottomLeftRadius = Declaration BorderBottomLeftRadius <<< expand
+
+borderBottomRightRadius :: BorderRadiusValue -> Declaration
+borderBottomRightRadius = Declaration BorderBottomRightRadius <<< expand
+
+borderTopLeftRadius :: BorderRadiusValue -> Declaration
+borderTopLeftRadius = Declaration BorderTopLeftRadius <<< expand
+
+borderTopRightRadius :: BorderRadiusValue -> Declaration
+borderTopRightRadius = Declaration BorderTopRightRadius <<< expand
 
 
 type ColorValue =
@@ -119,8 +141,18 @@ type MarginValue =
     + ()
     )
 
-margin :: MarginValue -> Declaration
-margin = Declaration Margin <<< expand
+margin
+  :: MarginValue
+  -> MarginValue
+  -> MarginValue
+  -> MarginValue
+  -> Array Declaration
+margin t r b l =
+  [ marginTop t
+  , marginRight r
+  , marginBottom b
+  , marginLeft l
+  ]
 
 marginBottom :: MarginValue -> Declaration
 marginBottom = Declaration MarginBottom <<< expand
@@ -134,6 +166,17 @@ marginRight = Declaration MarginRight <<< expand
 marginTop :: MarginValue -> Declaration
 marginTop = Declaration MarginTop <<< expand
 
+
+outline
+  :: OutlineWidthValue
+  -> OutlineStyleValue
+  -> OutlineColorValue
+  -> Array Declaration
+outline w s c =
+  [ outlineWidth w
+  , outlineStyle s
+  , outlineColor c
+  ]
 
 type OutlineColorValue =
   Variant
@@ -189,8 +232,18 @@ type PaddingValue =
     + ()
     )
 
-padding :: PaddingValue -> Declaration
-padding = Declaration Padding <<< expand
+padding
+  :: PaddingValue
+  -> PaddingValue
+  -> PaddingValue
+  -> PaddingValue
+  -> Array Declaration
+padding t r b l =
+  [ paddingTop t
+  , paddingRight r
+  , paddingBottom b
+  , paddingLeft l
+  ]
 
 paddingBottom :: PaddingValue -> Declaration
 paddingBottom = Declaration PaddingBottom <<< expand

--- a/src/Style/Declaration/Property.purs
+++ b/src/Style/Declaration/Property.purs
@@ -4,12 +4,14 @@ import Prelude
 
 data Property
   = BackgroundColor
-  | BorderRadius
+  | BorderBottomLeftRadius
+  | BorderBottomRightRadius
+  | BorderTopLeftRadius
+  | BorderTopRightRadius
   | Color
   | FontSize
   | FontWeight
   | Height
-  | Margin
   | MarginBottom
   | MarginLeft
   | MarginRight
@@ -17,7 +19,6 @@ data Property
   | OutlineColor
   | OutlineStyle
   | OutlineWidth
-  | Padding
   | PaddingBottom
   | PaddingLeft
   | PaddingRight
@@ -31,12 +32,14 @@ derive instance ordProperty :: Ord Property
 instance showProperty :: Show Property where
   show = case _ of
     BackgroundColor -> "BackgroundColor"
-    BorderRadius -> "BorderRadius"
+    BorderBottomLeftRadius -> "BorderBottomLeftRadius"
+    BorderBottomRightRadius -> "BorderBottomRightRadius"
+    BorderTopLeftRadius -> "BorderTopLeftRadius"
+    BorderTopRightRadius -> "BorderTopRightRadius"
     Color -> "Color"
     FontSize -> "FontSize"
     FontWeight -> "FontWeight"
     Height -> "Height"
-    Margin -> "Margin"
     MarginBottom -> "MarginBottom"
     MarginLeft -> "MarginLeft"
     MarginRight -> "MarginRight"
@@ -44,7 +47,6 @@ instance showProperty :: Show Property where
     OutlineColor -> "OutlineColor"
     OutlineStyle -> "OutlineStyle"
     OutlineWidth -> "OutlineWidth"
-    Padding -> "Padding"
     PaddingBottom -> "PaddingBottom"
     PaddingLeft -> "PaddingLeft"
     PaddingRight -> "PaddingRight"
@@ -55,12 +57,14 @@ instance showProperty :: Show Property where
 render :: Property -> String
 render = case _ of
   BackgroundColor -> "background-color"
-  BorderRadius -> "border-radius"
+  BorderBottomLeftRadius -> "border-bottom-left-radius"
+  BorderBottomRightRadius -> "border-bottom-right-radius"
+  BorderTopLeftRadius -> "border-top-left-radius"
+  BorderTopRightRadius -> "border-top-right-radius"
   Color -> "color"
   FontSize -> "font-size"
   FontWeight -> "font-weight"
   Height -> "height"
-  Margin -> "margin"
   MarginBottom -> "margin-bottom"
   MarginLeft -> "margin-left"
   MarginRight -> "margin-right"
@@ -68,7 +72,6 @@ render = case _ of
   OutlineColor -> "outline-color"
   OutlineStyle -> "outline-style"
   OutlineWidth -> "outline-width"
-  Padding -> "padding"
   PaddingBottom -> "padding-bottom"
   PaddingLeft -> "padding-left"
   PaddingRight -> "padding-right"

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -7,8 +7,8 @@ import Data.Array.NonEmpty (NonEmptyArray, fromArray)
 import Data.Maybe (Maybe, maybe)
 import Effect (Effect)
 import Effect.Console (log)
-import Style.Declaration (Declaration, backgroundColor, borderRadius, color, fontSize, fontWeight, height, margin, outlineStyle, padding, textAlign, width)
-import Style.Declaration.Value (auto, center, em, none, number, pct, px, zero)
+import Style.Declaration (Declaration, backgroundColor, borderRadius, color, fontSize, fontWeight, height, margin, outline, padding, textAlign, width)
+import Style.Declaration.Value (auto, center, currentColor, em, in_, mm, number, pct, px, rem, solid, zero)
 import Style.Render (inline)
 import Style.Ruleset (Ruleset(..))
 import Style.Ruleset as Ruleset
@@ -22,19 +22,19 @@ selectors = fromArray
   ]
 
 declarations :: Maybe (NonEmptyArray Declaration)
-declarations = fromArray
+declarations = fromArray $
   [ backgroundColor $ rgb 127 127 127
-  , borderRadius $ 8.0 # px
   , color black
   , fontSize $ 16.0 # px
   , fontWeight $ number 300.0
   , height $ 100.0 # pct
-  , margin zero
-  , outlineStyle none
-  , padding $ 2.0 # em
   , textAlign center
   , width auto
   ]
+  <> borderRadius (8.0 # px) (8.0 # px) (8.0 # px) (8.0 # px)
+  <> margin auto (8.0 # px) (50.0 # pct) zero
+  <> outline (1.0 # px) solid currentColor
+  <> padding (1.0 # em) (2.0 # in_) (3.0 # mm) (4.0 # rem)
 
 ruleset :: Maybe Ruleset
 ruleset = Ruleset <$> selectors <*> declarations


### PR DESCRIPTION
This is the first part of what I mentioned in https://github.com/paulyoung/purescript-style/pull/19#issuecomment-398621221:

> I think what I'd like to do for now is not provide any shorthand versions and perhaps later provide functions whose return type are `Array Declaration`, combined with a phase that recognizes longhand properties and renders them as shorthand.